### PR TITLE
Make OAuth2 module's functions unary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,3 @@ install:
  - npm install
 script:
  - npm test
- os:
- - windows

--- a/dist/oauth2/getAccessToken.d.ts
+++ b/dist/oauth2/getAccessToken.d.ts
@@ -1,10 +1,7 @@
 import { AccessTokenResponse } from '../shared/interfaces/AccessTokenResponse';
-/**
- * Exchanges the OAuth2 code for an access token and its details (username, expiration time and optionally refresh token) and returns them.
- * @param {string} clientId The client id of the SteemConnect app.
- * @param {string} clientSecret The client secret of the SteemConnect app.
- * @param {string} redirectUri The redirect URI used in the getAuthorizationUrl function.
- * @param {string} code The OAuth2 code.
- * @returns {Promise} Promise object that resolves into the access token + its details object.
- */
-export declare function getAccessToken(clientId: string, clientSecret: string, redirectUri: string, code: string): Promise<AccessTokenResponse>;
+export declare function getAccessToken({clientId, clientSecret, redirectUri, code}: {
+    clientId: string;
+    clientSecret: string;
+    redirectUri: string;
+    code: string;
+}): Promise<AccessTokenResponse>;

--- a/dist/oauth2/getAccessToken.d.ts
+++ b/dist/oauth2/getAccessToken.d.ts
@@ -1,7 +1,6 @@
+import { ClientCredenctials } from './interfaces/ClientCredentials';
 import { AccessTokenResponse } from '../shared/interfaces/AccessTokenResponse';
-export declare function getAccessToken({clientId, clientSecret, redirectUri, code}: {
-    clientId: string;
-    clientSecret: string;
+export declare function getAccessToken({clientId, clientSecret, redirectUri, code}: ClientCredenctials & {
     redirectUri: string;
     code: string;
 }): Promise<AccessTokenResponse>;

--- a/dist/oauth2/getAccessToken.js
+++ b/dist/oauth2/getAccessToken.js
@@ -9,15 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const rp = require("request-promise");
-/**
- * Exchanges the OAuth2 code for an access token and its details (username, expiration time and optionally refresh token) and returns them.
- * @param {string} clientId The client id of the SteemConnect app.
- * @param {string} clientSecret The client secret of the SteemConnect app.
- * @param {string} redirectUri The redirect URI used in the getAuthorizationUrl function.
- * @param {string} code The OAuth2 code.
- * @returns {Promise} Promise object that resolves into the access token + its details object.
- */
-function getAccessToken(clientId, clientSecret, redirectUri, code) {
+function getAccessToken({ clientId, clientSecret, redirectUri, code }) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const options = {

--- a/dist/oauth2/getAuthorizationUrl.d.ts
+++ b/dist/oauth2/getAuthorizationUrl.d.ts
@@ -1,5 +1,5 @@
-export declare function getAuthorizationUrl({clientId, redirectUri, scope, state}: {
-    clientId: string;
+import { ClientCredenctials } from './interfaces/ClientCredentials';
+export declare function getAuthorizationUrl({clientId, redirectUri, scope, state}: ClientCredenctials & {
     redirectUri: string;
     scope: Array<string>;
     state?: string;

--- a/dist/oauth2/getAuthorizationUrl.d.ts
+++ b/dist/oauth2/getAuthorizationUrl.d.ts
@@ -1,9 +1,6 @@
-/**
- * Creates and returns the authorization URL to SteemConnect OAuth2 service.
- * @param {string} clientId The client id of the SteemConnect app.
- * @param {string} redirectUri The URI you want the user to be redirected to after successful login.
- * @param {Array} scope The array of scopes (ex. ['vote', 'comment']).
- * @param {string} [state] Optional state variable
- * @returns {string} The URL of the SteemConnect OAuth2 authorization endpoint.
- */
-export declare function getAuthorizationUrl(clientId: string, redirectUri: string, scope: Array<string>, state?: string): string;
+export declare function getAuthorizationUrl({clientId, redirectUri, scope, state}: {
+    clientId: string;
+    redirectUri: string;
+    scope: Array<string>;
+    state?: string;
+}): string;

--- a/dist/oauth2/getAuthorizationUrl.js
+++ b/dist/oauth2/getAuthorizationUrl.js
@@ -1,15 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const qs = require("querystring");
-/**
- * Creates and returns the authorization URL to SteemConnect OAuth2 service.
- * @param {string} clientId The client id of the SteemConnect app.
- * @param {string} redirectUri The URI you want the user to be redirected to after successful login.
- * @param {Array} scope The array of scopes (ex. ['vote', 'comment']).
- * @param {string} [state] Optional state variable
- * @returns {string} The URL of the SteemConnect OAuth2 authorization endpoint.
- */
-function getAuthorizationUrl(clientId, redirectUri, scope, state) {
+function getAuthorizationUrl({ clientId, redirectUri, scope, state }) {
     const base = 'https://steemconnect.com/oauth2/authorize?';
     const queryParams = {
         client_id: clientId,

--- a/dist/oauth2/getAuthorizationUrl.js
+++ b/dist/oauth2/getAuthorizationUrl.js
@@ -1,14 +1,14 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const qs = require("querystring");
-function getAuthorizationUrl({ clientId, redirectUri, scope, state }) {
+function getAuthorizationUrl({ clientId, redirectUri, scope, state = '' }) {
     const base = 'https://steemconnect.com/oauth2/authorize?';
     const queryParams = {
         client_id: clientId,
         response_type: 'code',
         redirect_uri: redirectUri,
         scope: scope.join(','),
-        state: state || null
+        state
     };
     const endpoint = base + qs.stringify(queryParams);
     return endpoint;

--- a/dist/oauth2/interfaces/ClientCredentials.d.ts
+++ b/dist/oauth2/interfaces/ClientCredentials.d.ts
@@ -1,0 +1,4 @@
+export interface ClientCredenctials {
+    clientId: string;
+    clientSecret?: string;
+}

--- a/dist/oauth2/interfaces/ClientCredentials.js
+++ b/dist/oauth2/interfaces/ClientCredentials.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/dist/oauth2/refreshAccessToken.d.ts
+++ b/dist/oauth2/refreshAccessToken.d.ts
@@ -1,6 +1,5 @@
+import { ClientCredenctials } from './interfaces/ClientCredentials';
 import { AccessTokenResponse } from '../shared/interfaces/AccessTokenResponse';
-export declare function refreshAccessToken({clientId, clientSecret, refreshToken}: {
-    clientId: string;
-    clientSecret: string;
+export declare function refreshAccessToken({clientId, clientSecret, refreshToken}: ClientCredenctials & {
     refreshToken: string;
 }): Promise<AccessTokenResponse>;

--- a/dist/oauth2/refreshAccessToken.d.ts
+++ b/dist/oauth2/refreshAccessToken.d.ts
@@ -1,9 +1,6 @@
 import { AccessTokenResponse } from '../shared/interfaces/AccessTokenResponse';
-/**
- * Exchanges the refresh token for the new access token and its details (username, expiration time and refresh token) and returns them.
- * @param {string} clientId The client id of the SteemConnect app.
- * @param {string} clientSecret The client secret of the SteemConnect app.
- * @param {string} refreshToken The refresh_token of the user you want to get new access token for.
- * @returns {Promise} Promise object that resolves into the new access token + its details object.
- */
-export declare function refreshAccessToken(clientId: string, clientSecret: string, refreshToken: string): Promise<AccessTokenResponse>;
+export declare function refreshAccessToken({clientId, clientSecret, refreshToken}: {
+    clientId: string;
+    clientSecret: string;
+    refreshToken: string;
+}): Promise<AccessTokenResponse>;

--- a/dist/oauth2/refreshAccessToken.js
+++ b/dist/oauth2/refreshAccessToken.js
@@ -9,14 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const rp = require("request-promise");
-/**
- * Exchanges the refresh token for the new access token and its details (username, expiration time and refresh token) and returns them.
- * @param {string} clientId The client id of the SteemConnect app.
- * @param {string} clientSecret The client secret of the SteemConnect app.
- * @param {string} refreshToken The refresh_token of the user you want to get new access token for.
- * @returns {Promise} Promise object that resolves into the new access token + its details object.
- */
-function refreshAccessToken(clientId, clientSecret, refreshToken) {
+function refreshAccessToken({ clientId, clientSecret, refreshToken }) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const options = {

--- a/dist/oauth2/revokeAccessToken.d.ts
+++ b/dist/oauth2/revokeAccessToken.d.ts
@@ -1,6 +1,1 @@
-/**
- * Revokes given access token.
- * @param {string} accessToken The access token to revoke.
- * @returns {Promise} Promise object that resolves into the result of revoking token.
- */
 export declare function revokeAccessToken(accessToken: string): Promise<any>;

--- a/dist/oauth2/revokeAccessToken.js
+++ b/dist/oauth2/revokeAccessToken.js
@@ -9,11 +9,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const rp = require("request-promise");
-/**
- * Revokes given access token.
- * @param {string} accessToken The access token to revoke.
- * @returns {Promise} Promise object that resolves into the result of revoking token.
- */
 function revokeAccessToken(accessToken) {
     return __awaiter(this, void 0, void 0, function* () {
         try {

--- a/dist/oauth2/revokeAccessToken.js
+++ b/dist/oauth2/revokeAccessToken.js
@@ -21,7 +21,7 @@ function revokeAccessToken(accessToken) {
                 },
                 json: true
             };
-            const result = yield rp.delete(options);
+            const result = yield rp.post(options);
             return result;
         }
         catch (e) {

--- a/dist/oauth2/setUserMetadata.d.ts
+++ b/dist/oauth2/setUserMetadata.d.ts
@@ -1,8 +1,5 @@
 import { UserData } from '../shared/interfaces/UserData';
-/**
- * Sets user metadata and returns the user data of this user.
- * @param {string} accessToken The access_token of the user.
- * @param {object} metadata The metadata to set.
- * @returns {Promise} Promise object that resolves into user data object.
- */
-export declare function setUserMetadata(accessToken: string, metadata: object): Promise<UserData>;
+export declare function setUserMetadata({accessToken, metadata}: {
+    accessToken: string;
+    metadata: object;
+}): Promise<UserData>;

--- a/dist/oauth2/setUserMetadata.js
+++ b/dist/oauth2/setUserMetadata.js
@@ -9,13 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const rp = require("request-promise");
-/**
- * Sets user metadata and returns the user data of this user.
- * @param {string} accessToken The access_token of the user.
- * @param {object} metadata The metadata to set.
- * @returns {Promise} Promise object that resolves into user data object.
- */
-function setUserMetadata(accessToken, metadata) {
+function setUserMetadata({ accessToken, metadata }) {
     return __awaiter(this, void 0, void 0, function* () {
         const metadataClone = Object.assign({}, metadata);
         const userMetadata = {

--- a/src/oauth2/getAccessToken.ts
+++ b/src/oauth2/getAccessToken.ts
@@ -1,3 +1,4 @@
+import { ClientCredenctials } from './interfaces/ClientCredentials';
 import { AccessTokenResponse } from '../shared/interfaces/AccessTokenResponse';
 
 import * as rp from 'request-promise';
@@ -7,9 +8,7 @@ export async function getAccessToken({
   clientSecret,
   redirectUri,
   code
-}: {
-  clientId: string;
-  clientSecret: string;
+}: ClientCredenctials & {
   redirectUri: string;
   code: string;
 }): Promise<AccessTokenResponse> {

--- a/src/oauth2/getAccessToken.ts
+++ b/src/oauth2/getAccessToken.ts
@@ -2,20 +2,17 @@ import { AccessTokenResponse } from '../shared/interfaces/AccessTokenResponse';
 
 import * as rp from 'request-promise';
 
-/**
- * Exchanges the OAuth2 code for an access token and its details (username, expiration time and optionally refresh token) and returns them.
- * @param {string} clientId The client id of the SteemConnect app.
- * @param {string} clientSecret The client secret of the SteemConnect app.
- * @param {string} redirectUri The redirect URI used in the getAuthorizationUrl function.
- * @param {string} code The OAuth2 code.
- * @returns {Promise} Promise object that resolves into the access token + its details object.
- */
-export async function getAccessToken(
-  clientId: string,
-  clientSecret: string,
-  redirectUri: string,
-  code: string
-): Promise<AccessTokenResponse> {
+export async function getAccessToken({
+  clientId,
+  clientSecret,
+  redirectUri,
+  code
+}: {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  code: string;
+}): Promise<AccessTokenResponse> {
   try {
     const options = {
       uri: 'https://steemconnect.com/api/oauth2/token',

--- a/src/oauth2/getAuthorizationUrl.ts
+++ b/src/oauth2/getAuthorizationUrl.ts
@@ -1,19 +1,16 @@
 import * as qs from 'querystring';
 
-/**
- * Creates and returns the authorization URL to SteemConnect OAuth2 service.
- * @param {string} clientId The client id of the SteemConnect app.
- * @param {string} redirectUri The URI you want the user to be redirected to after successful login.
- * @param {Array} scope The array of scopes (ex. ['vote', 'comment']).
- * @param {string} [state] Optional state variable
- * @returns {string} The URL of the SteemConnect OAuth2 authorization endpoint.
- */
-export function getAuthorizationUrl(
-  clientId: string,
-  redirectUri: string,
-  scope: Array<string>,
-  state?: string
-): string {
+export function getAuthorizationUrl({
+  clientId,
+  redirectUri,
+  scope,
+  state
+}: {
+  clientId: string;
+  redirectUri: string;
+  scope: Array<string>;
+  state?: string;
+}): string {
   const base = 'https://steemconnect.com/oauth2/authorize?';
   const queryParams = {
     client_id: clientId,

--- a/src/oauth2/getAuthorizationUrl.ts
+++ b/src/oauth2/getAuthorizationUrl.ts
@@ -5,7 +5,7 @@ export function getAuthorizationUrl({
   clientId,
   redirectUri,
   scope,
-  state
+  state = ''
 }: ClientCredenctials & {
   redirectUri: string;
   scope: Array<string>;
@@ -17,7 +17,7 @@ export function getAuthorizationUrl({
     response_type: 'code',
     redirect_uri: redirectUri,
     scope: scope.join(','),
-    state: state || null
+    state
   };
   const endpoint = base + qs.stringify(queryParams);
   return endpoint;

--- a/src/oauth2/getAuthorizationUrl.ts
+++ b/src/oauth2/getAuthorizationUrl.ts
@@ -1,3 +1,4 @@
+import { ClientCredenctials } from './interfaces/ClientCredentials';
 import * as qs from 'querystring';
 
 export function getAuthorizationUrl({
@@ -5,8 +6,7 @@ export function getAuthorizationUrl({
   redirectUri,
   scope,
   state
-}: {
-  clientId: string;
+}: ClientCredenctials & {
   redirectUri: string;
   scope: Array<string>;
   state?: string;

--- a/src/oauth2/interfaces/ClientCredentials.ts
+++ b/src/oauth2/interfaces/ClientCredentials.ts
@@ -1,0 +1,4 @@
+export interface ClientCredenctials {
+  clientId: string;
+  clientSecret?: string;
+}

--- a/src/oauth2/refreshAccessToken.ts
+++ b/src/oauth2/refreshAccessToken.ts
@@ -1,3 +1,4 @@
+import { ClientCredenctials } from './interfaces/ClientCredentials';
 import { AccessTokenResponse } from '../shared/interfaces/AccessTokenResponse';
 import * as rp from 'request-promise';
 
@@ -5,9 +6,7 @@ export async function refreshAccessToken({
   clientId,
   clientSecret,
   refreshToken
-}: {
-  clientId: string;
-  clientSecret: string;
+}: ClientCredenctials & {
   refreshToken: string;
 }): Promise<AccessTokenResponse> {
   try {

--- a/src/oauth2/refreshAccessToken.ts
+++ b/src/oauth2/refreshAccessToken.ts
@@ -1,19 +1,15 @@
 import { AccessTokenResponse } from '../shared/interfaces/AccessTokenResponse';
-
 import * as rp from 'request-promise';
 
-/**
- * Exchanges the refresh token for the new access token and its details (username, expiration time and refresh token) and returns them.
- * @param {string} clientId The client id of the SteemConnect app.
- * @param {string} clientSecret The client secret of the SteemConnect app.
- * @param {string} refreshToken The refresh_token of the user you want to get new access token for.
- * @returns {Promise} Promise object that resolves into the new access token + its details object.
- */
-export async function refreshAccessToken(
-  clientId: string,
-  clientSecret: string,
-  refreshToken: string
-): Promise<AccessTokenResponse> {
+export async function refreshAccessToken({
+  clientId,
+  clientSecret,
+  refreshToken
+}: {
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+}): Promise<AccessTokenResponse> {
   try {
     const options = {
       uri: 'https://steemconnect.com/api/oauth2/token',

--- a/src/oauth2/revokeAccessToken.ts
+++ b/src/oauth2/revokeAccessToken.ts
@@ -12,7 +12,7 @@ export async function revokeAccessToken(accessToken: string) {
       json: true
     };
 
-    const result = await rp.delete(options);
+    const result = await rp.post(options);
     return result;
   } catch (e) {
     throw e.error;

--- a/src/oauth2/revokeAccessToken.ts
+++ b/src/oauth2/revokeAccessToken.ts
@@ -1,10 +1,5 @@
 import * as rp from 'request-promise';
 
-/**
- * Revokes given access token.
- * @param {string} accessToken The access token to revoke.
- * @returns {Promise} Promise object that resolves into the result of revoking token.
- */
 export async function revokeAccessToken(accessToken: string) {
   try {
     const options = {

--- a/src/oauth2/setUserMetadata.ts
+++ b/src/oauth2/setUserMetadata.ts
@@ -1,17 +1,13 @@
 import { UserData } from '../shared/interfaces/UserData';
-
 import * as rp from 'request-promise';
 
-/**
- * Sets user metadata and returns the user data of this user.
- * @param {string} accessToken The access_token of the user.
- * @param {object} metadata The metadata to set.
- * @returns {Promise} Promise object that resolves into user data object.
- */
-export async function setUserMetadata(
-  accessToken: string,
-  metadata: object
-): Promise<UserData> {
+export async function setUserMetadata({
+  accessToken,
+  metadata
+}: {
+  accessToken: string;
+  metadata: object;
+}): Promise<UserData> {
   const metadataClone = Object.assign({}, metadata);
   const userMetadata = {
     user_metadata: metadataClone

--- a/tests/oauth2/getAccessToken.spec.ts
+++ b/tests/oauth2/getAccessToken.spec.ts
@@ -18,12 +18,12 @@ describe('getAccessToken', () => {
         username: 'dev'
       });
 
-    const result = await getAccessToken(
+    const result = await getAccessToken({
       clientId,
       clientSecret,
       redirectUri,
       code
-    );
+    });
 
     expect(result.username).to.equal('dev');
     expect(result.access_token).to.equal('ey.eyJy4MDI5NjU3fQ.lqX2bTkW7R');
@@ -37,7 +37,7 @@ describe('getAccessToken', () => {
         error_description: 'The token has invalid role'
       });
 
-    return getAccessToken(clientId, clientSecret, redirectUri, code).catch(
+    return getAccessToken({ clientId, clientSecret, redirectUri, code }).catch(
       err => {
         expect(err).to.exist.and.have.property('error');
       }

--- a/tests/oauth2/getAuthorizationUrl.spec.ts
+++ b/tests/oauth2/getAuthorizationUrl.spec.ts
@@ -8,7 +8,11 @@ describe('getAuthorizationUrl', () => {
     const redirectUri = 'https://wykop.pl/redirect';
     const scope = ['vote'];
 
-    const authorizationUrl = getAuthorizationUrl(clientId, redirectUri, scope);
+    const authorizationUrl = getAuthorizationUrl({
+      clientId,
+      redirectUri,
+      scope
+    });
 
     expect(authorizationUrl).to.equal(
       'https://steemconnect.com/oauth2/authorize?client_id=test.app&response_type=code&redirect_uri=https%3A%2F%2Fwykop.pl%2Fredirect&scope=vote&state='
@@ -20,7 +24,11 @@ describe('getAuthorizationUrl', () => {
     const redirectUri = 'https://adam.malysz/redirect';
     const scope = ['vote', 'comment'];
 
-    const authorizationUrl = getAuthorizationUrl(clientId, redirectUri, scope);
+    const authorizationUrl = getAuthorizationUrl({
+      clientId,
+      redirectUri,
+      scope
+    });
 
     expect(authorizationUrl).to.equal(
       'https://steemconnect.com/oauth2/authorize?client_id=test.app&response_type=code&redirect_uri=https%3A%2F%2Fadam.malysz%2Fredirect&scope=vote%2Ccomment&state='
@@ -33,12 +41,12 @@ describe('getAuthorizationUrl', () => {
     const scope = ['vote'];
     const state = 'state342343243242';
 
-    const authorizationUrl = getAuthorizationUrl(
+    const authorizationUrl = getAuthorizationUrl({
       clientId,
       redirectUri,
       scope,
       state
-    );
+    });
 
     expect(authorizationUrl).to.equal(
       'https://steemconnect.com/oauth2/authorize?client_id=test.app&response_type=code&redirect_uri=https%3A%2F%2Fmyapp.com%2Fredirect&scope=vote&state=state342343243242'

--- a/tests/oauth2/refreshAccessToken.spec.ts
+++ b/tests/oauth2/refreshAccessToken.spec.ts
@@ -18,11 +18,11 @@ describe('refreshAccessToken', () => {
       });
     const refreshToken = 'valid.refresh.token';
 
-    const newAccessToken = await refreshAccessToken(
+    const newAccessToken = await refreshAccessToken({
       clientId,
       clientSecret,
       refreshToken
-    );
+    });
 
     expect(newAccessToken).to.exist.and.have.property('access_token');
   });
@@ -36,8 +36,8 @@ describe('refreshAccessToken', () => {
       });
     const refreshToken = 'invalid.refresh.token';
 
-    return refreshAccessToken(clientId, clientSecret, refreshToken).catch(err =>
-      expect(err).to.exist.and.have.property('error_description')
+    return refreshAccessToken({ clientId, clientSecret, refreshToken }).catch(
+      err => expect(err).to.exist.and.have.property('error_description')
     );
   });
 });

--- a/tests/oauth2/revokeAccessToken.spec.ts
+++ b/tests/oauth2/revokeAccessToken.spec.ts
@@ -1,4 +1,8 @@
 import { revokeAccessToken } from '../../src/oauth2/revokeAccessToken';
+import {
+  ACCESS_TOKEN_REVOKED,
+  ACCESS_TOKEN_INVALID
+} from './../../src/shared/errors/constants';
 
 import { expect } from 'chai';
 import * as nock from 'nock';
@@ -8,7 +12,7 @@ describe('revokeAccessToken', () => {
 
   it('should revoke an access token if access token is correct', async () => {
     nock('https://steemconnect.com')
-      .delete('/api/oauth2/token/revoke')
+      .post('/api/oauth2/token/revoke')
       .reply(200, {
         success: true
       });
@@ -22,11 +26,8 @@ describe('revokeAccessToken', () => {
 
   it('should throw if access token is incorrect', () => {
     nock('https://steemconnect.com')
-      .delete('/api/oauth2/token/revoke')
-      .replyWithError({
-        error: 'invalid_grant',
-        error_description: 'The token has invalid role'
-      });
+      .post('/api/oauth2/token/revoke')
+      .replyWithError(ACCESS_TOKEN_INVALID);
 
     return revokeAccessToken(accessToken).catch(error =>
       expect(error).to.exist.and.deep.equal({
@@ -38,11 +39,8 @@ describe('revokeAccessToken', () => {
 
   it('should throw if access token has already been revoked', () => {
     nock('https://steemconnect.com')
-      .delete('/api/oauth2/token/revoke')
-      .replyWithError({
-        error: 'invalid_grant',
-        error_description: 'The access_token has been revoked'
-      });
+      .post('/api/oauth2/token/revoke')
+      .replyWithError(ACCESS_TOKEN_REVOKED);
 
     return revokeAccessToken(accessToken).catch(error =>
       expect(error).to.exist.and.deep.equal({

--- a/tests/oauth2/setUserMetadata.spec.ts
+++ b/tests/oauth2/setUserMetadata.spec.ts
@@ -20,7 +20,7 @@ describe('setUserMetadata', () => {
         scope: ['vote', 'comment'],
         user_metadata: metadata
       });
-    const userData = await setUserMetadata(accessToken, metadata);
+    const userData = await setUserMetadata({ accessToken, metadata });
 
     expect(userData).to.exist.and.deep.include({
       user_metadata: { someValue: 'value' }
@@ -35,7 +35,7 @@ describe('setUserMetadata', () => {
         error_description: 'The token has invalid role'
       });
 
-    return setUserMetadata(accessToken, metadata).catch(err => {
+    return setUserMetadata({ accessToken, metadata }).catch(err => {
       expect(err).to.exist;
     });
   });


### PR DESCRIPTION
To serve consistent developer experience, I've refactored OAuth2 module's functions, so now they are **unary**.

I've also removed JSDocs in this module as it is not gonna be useful anymore.