### PR TITLE
Reliable broadcasting as a wrapper function

### DIFF
--- a/dist/broadcasting/interfaces/index.d.ts
+++ b/dist/broadcasting/interfaces/index.d.ts
@@ -1,0 +1,8 @@
+export { BroadcastResult } from './BroadcastResult';
+export { Comment } from './Comment';
+export { Follow } from './Follow';
+export { Post } from './Post';
+export { PostWithBeneficiaries } from './PostWithBeneficiaries';
+export { Reblog } from './Reblog';
+export { Unfollow } from './Unfollow';
+export { Vote } from './Vote';

--- a/dist/broadcasting/interfaces/index.js
+++ b/dist/broadcasting/interfaces/index.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/dist/broadcasting/rely.d.ts
+++ b/dist/broadcasting/rely.d.ts
@@ -1,0 +1,4 @@
+import { BroadcastResult } from './interfaces/BroadcastResult';
+import { ClientCredenctials } from './../oauth2/interfaces/ClientCredentials';
+import { AccessTokenResponse } from './../shared/interfaces/AccessTokenResponse';
+export declare const rely: ({ clientId, clientSecret }: ClientCredenctials) => ({ access_token, refresh_token }: AccessTokenResponse) => (broadcastable: Function) => Promise<BroadcastResult & Partial<AccessTokenResponse>>;

--- a/dist/broadcasting/rely.d.ts
+++ b/dist/broadcasting/rely.d.ts
@@ -1,4 +1,4 @@
 import { BroadcastResult } from './interfaces/BroadcastResult';
 import { ClientCredenctials } from './../oauth2/interfaces/ClientCredentials';
 import { AccessTokenResponse } from './../shared/interfaces/AccessTokenResponse';
-export declare const rely: ({ clientId, clientSecret }: ClientCredenctials) => ({ access_token, refresh_token }: AccessTokenResponse) => (broadcastable: Function) => Promise<BroadcastResult & Partial<AccessTokenResponse>>;
+export declare const rely: ({ clientId, clientSecret }: ClientCredenctials) => ({ access_token, refresh_token }: Required<AccessTokenResponse>) => (broadcastable: Function) => Promise<BroadcastResult & Partial<AccessTokenResponse>>;

--- a/dist/broadcasting/rely.js
+++ b/dist/broadcasting/rely.js
@@ -10,7 +10,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", { value: true });
 const refreshAccessToken_1 = require("../oauth2/refreshAccessToken");
 const isAccessTokenExpiredError_1 = require("./../shared/errors/isAccessTokenExpiredError");
-exports.rely = ({ clientId, clientSecret }) => ({ access_token, refresh_token = '' }) => (broadcastable) => __awaiter(this, void 0, void 0, function* () {
+exports.rely = ({ clientId, clientSecret }) => ({ access_token, refresh_token }) => (broadcastable) => __awaiter(this, void 0, void 0, function* () {
     try {
         return yield broadcastable({ access_token });
     }

--- a/dist/broadcasting/rely.js
+++ b/dist/broadcasting/rely.js
@@ -1,0 +1,31 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const refreshAccessToken_1 = require("../oauth2/refreshAccessToken");
+const isAccessTokenExpiredError_1 = require("./../shared/errors/isAccessTokenExpiredError");
+exports.rely = ({ clientId, clientSecret }) => ({ access_token, refresh_token = '' }) => (broadcastable) => __awaiter(this, void 0, void 0, function* () {
+    try {
+        return yield broadcastable({ access_token });
+    }
+    catch (err) {
+        if (isAccessTokenExpiredError_1.isAccessTokenExpiredError(err)) {
+            const refreshedTokens = yield refreshAccessToken_1.refreshAccessToken({
+                clientId,
+                clientSecret,
+                refreshToken: refresh_token
+            });
+            const broadcastResult = yield broadcastable({
+                access_token: refreshedTokens.access_token
+            });
+            return Object.assign({}, refreshedTokens, broadcastResult);
+        }
+        throw err;
+    }
+});

--- a/src/broadcasting/rely.ts
+++ b/src/broadcasting/rely.ts
@@ -1,0 +1,25 @@
+import { refreshAccessToken } from '../oauth2/refreshAccessToken';
+import { pipe } from './../shared/utils';
+import { isAccessTokenError } from './../shared/errors/isAccessTokenError';
+import { AccessTokenResponse } from './../shared/interfaces/AccessTokenResponse';
+
+export const rely = ({ clientId, clientSecret }) => ({
+  access_token,
+  refresh_token
+}: AccessTokenResponse) => async (broadcastable: Function) => {
+  try {
+    return await broadcastable({ access_token });
+  } catch (err) {
+    if (isAccessTokenError(err)) {
+      const refreshedTokens = await refreshAccessToken({
+        client_id,
+        client_secret,
+        refresh_token
+      });
+      return await broadcastable({
+        access_token: refreshedTokens.access_token
+      });
+    }
+    throw err;
+  }
+};

--- a/src/broadcasting/rely.ts
+++ b/src/broadcasting/rely.ts
@@ -6,8 +6,8 @@ import { AccessTokenResponse } from './../shared/interfaces/AccessTokenResponse'
 
 export const rely = ({ clientId, clientSecret }: ClientCredenctials) => ({
   access_token,
-  refresh_token = ''
-}: AccessTokenResponse) => async (
+  refresh_token
+}: Required<AccessTokenResponse>) => async (
   broadcastable: Function
 ): Promise<BroadcastResult & Partial<AccessTokenResponse>> => {
   try {

--- a/tests/broadcasting/rely.spec.ts
+++ b/tests/broadcasting/rely.spec.ts
@@ -1,0 +1,167 @@
+import { rely } from '../../src/broadcasting/rely';
+import { broadcastUpvote } from './../../src/broadcasting/broadcastUpvote';
+
+import { expect } from 'chai';
+import * as nock from 'nock';
+
+describe('rely', () => {
+  const clientCredentials = {
+    clientId: 'strimi.app',
+    clientSecret: '432rnj3nr23nkvfdvdf'
+  };
+  const tokens = {
+    access_token: 'fdsfertre',
+    expires_in: 4323432,
+    username: 'ned',
+    refresh_token: '3rk3m2krl3'
+  };
+  const voteConfig = {
+    voter: 'jakipatrikko',
+    author: 'whoever',
+    permlink: 'some-permlink',
+    weight: 10000
+  };
+
+  it('should broadcast if access_token is valid', async () => {
+    nock('https://steemconnect.com')
+      .post('/api/broadcast')
+      .reply(200, (uri, req) => ({
+        result: {
+          id: '43523bhbbv543hv5345',
+          block_num: 6546765,
+          trx_num: 1,
+          expired: false,
+          ref_block_num: 43223,
+          ref_block_prefix: 654645645,
+          expiration: '2018-02-11T01:12:42',
+          operations: req.operations,
+          extensions: [],
+          signatures: [
+            '4234bjhbhjbhjbhjbh5jb4325uiph235io45ioh3b45ug435b3hb5j3m5k23nm5j3nih5b34h5bn32on'
+          ]
+        }
+      }));
+
+    const result = await rely(clientCredentials)(tokens)(
+      broadcastUpvote(voteConfig)
+    );
+
+    expect(result).to.exist;
+    expect(result).to.have.property('result');
+  });
+
+  it('should broadcast if access_token is expired, but valid refresh_token was provided', async () => {
+    nock('https://steemconnect.com')
+      .post('/api/broadcast')
+      .once()
+      .replyWithError({
+        error: 'invalid_grant',
+        error_description: 'The token has invalid role'
+      });
+
+    nock('https://steemconnect.com')
+      .post('/api/oauth2/token')
+      .reply(200, {
+        access_token: 'ey.eyJy4MDI5NjU3fQ.lqX2bTkW7R',
+        expires_in: 604800,
+        username: 'ned',
+        refresh_token: 'gfd4t.432rrdf43.gfdger'
+      });
+
+    nock('https://steemconnect.com')
+      .post('/api/broadcast')
+      .once()
+      .reply(200, (uri, req) => ({
+        result: {
+          id: '43523bhbbv543hv5345',
+          block_num: 6546765,
+          trx_num: 1,
+          expired: false,
+          ref_block_num: 43223,
+          ref_block_prefix: 654645645,
+          expiration: '2018-02-11T01:12:42',
+          operations: req.operations,
+          extensions: [],
+          signatures: [
+            '4234bjhbhjbhjbhjbh5jb4325uiph235io45ioh3b45ug435b3hb5j3m5k23nm5j3nih5b34h5bn32on'
+          ]
+        }
+      }));
+
+    const result = await rely(clientCredentials)(tokens)(
+      broadcastUpvote(voteConfig)
+    );
+
+    expect(result).to.exist;
+    expect(result).to.have.property('result');
+  });
+
+  it('should return refreshed tokens if broadcast succeed after refreshing tokens', async () => {
+    nock('https://steemconnect.com')
+      .post('/api/broadcast')
+      .once()
+      .replyWithError({
+        error: 'invalid_grant',
+        error_description: 'The token has invalid role'
+      });
+
+    nock('https://steemconnect.com')
+      .post('/api/oauth2/token')
+      .reply(200, {
+        access_token: 'ey.eyJy4MDI5NjU3fQ.lqX2bTkW7R',
+        expires_in: 604800,
+        username: 'ned',
+        refresh_token: 'gfd4t.432rrdf43.gfdger'
+      });
+
+    nock('https://steemconnect.com')
+      .post('/api/broadcast')
+      .once()
+      .reply(200, (uri, req) => ({
+        result: {
+          id: '43523bhbbv543hv5345',
+          block_num: 6546765,
+          trx_num: 1,
+          expired: false,
+          ref_block_num: 43223,
+          ref_block_prefix: 654645645,
+          expiration: '2018-02-11T01:12:42',
+          operations: req.operations,
+          extensions: [],
+          signatures: [
+            '4234bjhbhjbhjbhjbh5jb4325uiph235io45ioh3b45ug435b3hb5j3m5k23nm5j3nih5b34h5bn32on'
+          ]
+        }
+      }));
+
+    const result = await rely(clientCredentials)(tokens)(
+      broadcastUpvote(voteConfig)
+    );
+
+    expect(result).to.exist;
+    expect(result).to.have.property('access_token');
+  });
+
+  it('should throw if both access_token and refresh_token are invalid', () => {
+    nock('https://steemconnect.com')
+      .post('/api/broadcast')
+      .once()
+      .replyWithError({
+        error: 'invalid_grant',
+        error_description: 'The token has invalid role'
+      });
+
+    nock('https://steemconnect.com')
+      .post('/api/oauth2/token')
+      .replyWithError({
+        error: 'invalid_grant',
+        error_description: 'The token has invalid role'
+      });
+
+    return rely(clientCredentials)(tokens)(broadcastUpvote(voteConfig)).catch(
+      err => {
+        expect(err).to.exist;
+      }
+    );
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,13 @@
     "strict": true
   },
   "exclude": ["node_modules", "tests/*.spec.ts"],
-  "include": ["src/*", "src/shared/", "src/shared/errors/*"]
+  "include": [
+    "src/*",
+    "src/broadcasting",
+    "src/firebase",
+    "src/oauth2",
+    "src/operation-creators",
+    "src/shared/",
+    "src/shared/errors/*"
+  ]
 }


### PR DESCRIPTION
- added a `rely` wrapper function which works like an HTTP interceptor (broadcasts even if `access_token` expired by refreshing it)
- fixed some compilation errors

Closes #15 