### PR TITLE
Fix wrong type in Post and PostWithBeneficiaries interfaces

### DIFF
--- a/dist/broadcasting/interfaces/Post.d.ts
+++ b/dist/broadcasting/interfaces/Post.d.ts
@@ -3,5 +3,5 @@ export interface Post {
     permlink: string;
     title: string;
     body: string;
-    metadata?: object | string;
+    metadata?: object;
 }

--- a/dist/broadcasting/interfaces/PostWithBeneficiaries.d.ts
+++ b/dist/broadcasting/interfaces/PostWithBeneficiaries.d.ts
@@ -5,5 +5,5 @@ export interface PostWithBeneficiaries {
     body: string;
     beneficiariesAccount: string;
     beneficiariesWeight: number;
-    metadata?: object | string;
+    metadata?: object;
 }

--- a/src/broadcasting/interfaces/Post.ts
+++ b/src/broadcasting/interfaces/Post.ts
@@ -3,5 +3,5 @@ export interface Post {
   permlink: string;
   title: string;
   body: string;
-  metadata?: object | string;
+  metadata?: object;
 }

--- a/src/broadcasting/interfaces/PostWithBeneficiaries.ts
+++ b/src/broadcasting/interfaces/PostWithBeneficiaries.ts
@@ -5,5 +5,5 @@ export interface PostWithBeneficiaries {
   body: string;
   beneficiariesAccount: string;
   beneficiariesWeight: number;
-  metadata?: object | string;
+  metadata?: object;
 }


### PR DESCRIPTION
- fixed possibility to pass a string as `metadata`